### PR TITLE
Fix mandatory test 6.1.24

### DIFF
--- a/lib/mandatoryTests/mandatoryTest_6_1_24.js
+++ b/lib/mandatoryTests/mandatoryTest_6_1_24.js
@@ -8,10 +8,9 @@ export default function mandatoryTest_6_1_24(doc) {
 
   // 6.1.24 Definition in Involvements
   if (preconditionFor_6_1_24_Matches(doc)) {
-    /** @type {Map<string, Set<string>>} */
-    const involvementMap = new Map()
-
     doc.vulnerabilities.forEach((vulnerability, vulnerabilityIndex) => {
+      /** @type {Map<string, Set<string>>} */
+      const involvementMap = new Map()
       vulnerability.involvements.forEach((involvement, involvementIndex) => {
         if (
           typeof involvement.date === 'string' &&

--- a/tests/mandatoryTest_6_1_24.js
+++ b/tests/mandatoryTest_6_1_24.js
@@ -1,0 +1,33 @@
+import { expect } from 'chai'
+import { mandatoryTest_6_1_24 } from '../mandatoryTests.js'
+import readExampleFiles from './shared/readExampleFiles.js'
+
+const failingExamples = await readExampleFiles(
+  new URL('mandatoryTest_6_1_24/failing', import.meta.url)
+)
+
+const validExamples = await readExampleFiles(
+  new URL('mandatoryTest_6_1_24/valid', import.meta.url)
+)
+
+describe('Optional test 6.2.14', function () {
+  describe('failing examples', function () {
+    for (const [title, failingExample] of failingExamples) {
+      it(title, async function () {
+        const result = await mandatoryTest_6_1_24(failingExample)
+
+        expect(result.errors).to.have.length.greaterThan(0)
+      })
+    }
+  })
+
+  describe('valid examples', function () {
+    for (const [title, validExample] of validExamples) {
+      it(title, async function () {
+        const result = await mandatoryTest_6_1_24(validExample)
+
+        expect(result.errors).to.haveOwnProperty('length', 0)
+      })
+    }
+  })
+})

--- a/tests/mandatoryTest_6_1_24/failing/oasis_csaf_tc-csaf_2_0-2021-6-1-24-01.json
+++ b/tests/mandatoryTest_6_1_24/failing/oasis_csaf_tc-csaf_2_0-2021-6-1-24-01.json
@@ -1,0 +1,43 @@
+{
+  "document": {
+    "category": "csaf_base",
+    "csaf_version": "2.0",
+    "publisher": {
+      "category": "other",
+      "name": "OASIS CSAF TC",
+      "namespace": "https://csaf.io"
+    },
+    "title": "Mandatory test: Multiple Definition in Involvements (failing example 1)",
+    "tracking": {
+      "current_release_date": "2021-07-21T10:00:00.000Z",
+      "id": "OASIS_CSAF_TC-CSAF_2.0-2021-6-1-24-01",
+      "initial_release_date": "2021-07-21T10:00:00.000Z",
+      "revision_history": [
+        {
+          "date": "2021-07-21T10:00:00.000Z",
+          "number": "1",
+          "summary": "Initial version."
+        }
+      ],
+      "status": "final",
+      "version": "1"
+    }
+  },
+  "vulnerabilities": [
+    {
+      "involvements": [
+        {
+          "date": "2021-04-23T10:00:00.000Z",
+          "party": "vendor",
+          "status": "completed"
+        },
+        {
+          "date": "2021-04-23T10:00:00.000Z",
+          "party": "vendor",
+          "status": "in_progress",
+          "summary": "The vendor has released a mitigation and is working to fully resolve the issue."
+        }
+      ]
+    }
+  ]
+}

--- a/tests/mandatoryTest_6_1_24/failing/oasis_csaf_tc-csaf_2_0-2021-6-1-24-02.json
+++ b/tests/mandatoryTest_6_1_24/failing/oasis_csaf_tc-csaf_2_0-2021-6-1-24-02.json
@@ -1,0 +1,43 @@
+{
+  "document": {
+    "category": "csaf_base",
+    "csaf_version": "2.0",
+    "publisher": {
+      "category": "other",
+      "name": "OASIS CSAF TC",
+      "namespace": "https://csaf.io"
+    },
+    "title": "Mandatory test: Multiple Definition in Involvements (failing example 2)",
+    "tracking": {
+      "current_release_date": "2021-07-21T10:00:00.000Z",
+      "id": "OASIS_CSAF_TC-CSAF_2.0-2021-6-1-24-02",
+      "initial_release_date": "2021-07-21T10:00:00.000Z",
+      "revision_history": [
+        {
+          "date": "2021-07-21T10:00:00.000Z",
+          "number": "1",
+          "summary": "Initial version."
+        }
+      ],
+      "status": "final",
+      "version": "1"
+    }
+  },
+  "vulnerabilities": [
+    {
+      "involvements": [
+        {
+          "date": "2021-04-23T10:00:00.000Z",
+          "party": "vendor",
+          "status": "in_progress"
+        },
+        {
+          "date": "2021-04-23T10:00:00.000Z",
+          "party": "vendor",
+          "status": "in_progress",
+          "summary": "The vendor has released a mitigation and is working to fully resolve the issue."
+        }
+      ]
+    }
+  ]
+}

--- a/tests/mandatoryTest_6_1_24/valid/oasis_csaf_tc-csaf_2_0-2021-6-1-24-11.json
+++ b/tests/mandatoryTest_6_1_24/valid/oasis_csaf_tc-csaf_2_0-2021-6-1-24-11.json
@@ -1,0 +1,47 @@
+{
+  "document": {
+    "category": "csaf_base",
+    "csaf_version": "2.0",
+    "publisher": {
+      "category": "other",
+      "name": "OASIS CSAF TC",
+      "namespace": "https://csaf.io"
+    },
+    "title": "Mandatory test: Multiple Definition in Involvements (valid example 1)",
+    "tracking": {
+      "current_release_date": "2021-07-21T10:00:00.000Z",
+      "id": "OASIS_CSAF_TC-CSAF_2.0-2021-6-1-24-11",
+      "initial_release_date": "2021-07-21T10:00:00.000Z",
+      "revision_history": [
+        {
+          "date": "2021-07-21T10:00:00.000Z",
+          "number": "1",
+          "summary": "Initial version."
+        }
+      ],
+      "status": "final",
+      "version": "1"
+    }
+  },
+  "vulnerabilities": [
+    {
+      "involvements": [
+        {
+          "date": "2021-04-23T10:00:00.000Z",
+          "party": "vendor",
+          "status": "completed"
+        }
+      ]
+    },
+    {
+      "involvements": [
+        {
+          "date": "2021-04-23T10:00:00.000Z",
+          "party": "vendor",
+          "status": "in_progress",
+          "summary": "The vendor has released a mitigation and is working to fully resolve the issue."
+        }
+      ]
+    }
+  ]
+}

--- a/tests/mandatoryTest_6_1_24/valid/oasis_csaf_tc-csaf_2_0-2021-6-1-24-12.json
+++ b/tests/mandatoryTest_6_1_24/valid/oasis_csaf_tc-csaf_2_0-2021-6-1-24-12.json
@@ -1,0 +1,47 @@
+{
+  "document": {
+    "category": "csaf_base",
+    "csaf_version": "2.0",
+    "publisher": {
+      "category": "other",
+      "name": "OASIS CSAF TC",
+      "namespace": "https://csaf.io"
+    },
+    "title": "Mandatory test: Multiple Definition in Involvements (valid example 2)",
+    "tracking": {
+      "current_release_date": "2021-07-21T10:00:00.000Z",
+      "id": "OASIS_CSAF_TC-CSAF_2.0-2021-6-1-24-12",
+      "initial_release_date": "2021-07-21T10:00:00.000Z",
+      "revision_history": [
+        {
+          "date": "2021-07-21T10:00:00.000Z",
+          "number": "1",
+          "summary": "Initial version."
+        }
+      ],
+      "status": "final",
+      "version": "1"
+    }
+  },
+  "vulnerabilities": [
+    {
+      "involvements": [
+        {
+          "date": "2021-04-23T10:00:00.000Z",
+          "party": "vendor",
+          "status": "in_progress"
+        }
+      ]
+    },
+    {
+      "involvements": [
+        {
+          "date": "2021-04-23T10:00:00.000Z",
+          "party": "vendor",
+          "status": "in_progress",
+          "summary": "The vendor has released a mitigation and is working to fully resolve the issue."
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
- fix(mandatoryTest_6_1_24): fixes #30 by checking involvements per vulnerability only
- test(mandatory_6_1_24): add test files from [OASIS repo](https://github.com/oasis-tcs/csaf/pull/571)