### PR TITLE
fix(mandatoryTest_6_1_30): allow empty revision history

### DIFF
--- a/lib/mandatoryTests/mandatoryTest_6_1_30.js
+++ b/lib/mandatoryTests/mandatoryTest_6_1_30.js
@@ -62,7 +62,7 @@ export default function mandatoryTest_6_1_30(doc) {
       }
     }
   })
-  if (typeof doc.document.tracking.version === 'string') {
+  if (versioningSchema != null && typeof doc.document.tracking.version === 'string') {
     if (
       versioningSchema !== detectVersionSchema(doc.document.tracking.version)
     ) {

--- a/tests/mandatoryTest_6_1_24.js
+++ b/tests/mandatoryTest_6_1_24.js
@@ -10,7 +10,7 @@ const validExamples = await readExampleFiles(
   new URL('mandatoryTest_6_1_24/valid', import.meta.url)
 )
 
-describe('Optional test 6.2.14', function () {
+describe('Mandatory test 6.1.24', function () {
   describe('failing examples', function () {
     for (const [title, failingExample] of failingExamples) {
       it(title, async function () {

--- a/tests/mandatoryTest_6_1_30.js
+++ b/tests/mandatoryTest_6_1_30.js
@@ -1,18 +1,15 @@
 import minimalDoc from './shared/minimalCSAFBaseDoc.js'
 
-import {expect} from 'chai'
-import {mandatoryTest_6_1_30} from '../mandatoryTests.js'
+import { expect } from 'chai'
+import { mandatoryTest_6_1_30 } from '../mandatoryTests.js'
 
 describe('Mandatory test 6.1.30', function () {
-
   it('should allow valid doc', function () {
-      const result = mandatoryTest_6_1_30(minimalDoc)
-      expect(result.errors).to.have.lengthOf(0)
-    }
-  )
+    const result = mandatoryTest_6_1_30(minimalDoc)
+    expect(result.errors).to.have.lengthOf(0)
+  })
 
   it('should fail on mixed integer and semantic versioning', function () {
-
     const result = mandatoryTest_6_1_30({
       ...minimalDoc,
       document: {
@@ -32,26 +29,21 @@ describe('Mandatory test 6.1.30', function () {
     })
 
     expect(result.errors).to.have.lengthOf(1)
-
   })
 
   it('allows an empty revision_history', function () {
+    const result = mandatoryTest_6_1_30({
+      ...minimalDoc,
+      document: {
+        ...minimalDoc.document,
+        tracking: {
+          ...minimalDoc.document.tracking,
+          revision_history: [],
+          version: '1',
+        },
+      },
+    })
 
-      const result = mandatoryTest_6_1_30(
-        {
-          ...minimalDoc,
-          document: {
-            ...minimalDoc.document,
-            tracking: {
-              ...minimalDoc.document.tracking,
-              revision_history: [],
-              version: '1',
-            },
-          },
-        }
-      )
-
-      expect(result.errors).to.have.lengthOf(0)
-    }
-  )
+    expect(result.errors).to.have.lengthOf(0)
+  })
 })

--- a/tests/mandatoryTest_6_1_30.js
+++ b/tests/mandatoryTest_6_1_30.js
@@ -1,0 +1,57 @@
+import minimalDoc from './shared/minimalCSAFBaseDoc.js'
+
+import {expect} from 'chai'
+import {mandatoryTest_6_1_30} from '../mandatoryTests.js'
+
+describe('Mandatory test 6.1.30', function () {
+
+  it('should allow valid doc', function () {
+      const result = mandatoryTest_6_1_30(minimalDoc)
+      expect(result.errors).to.have.lengthOf(0)
+    }
+  )
+
+  it('should fail on mixed integer and semantic versioning', function () {
+
+    const result = mandatoryTest_6_1_30({
+      ...minimalDoc,
+      document: {
+        ...minimalDoc.document,
+        tracking: {
+          ...minimalDoc.document.tracking,
+          revision_history: [
+            {
+              date: '2021-07-21T09:00:00.000Z',
+              number: '2.0.0',
+              summary: 'Initial version.',
+            },
+          ],
+          version: '2',
+        },
+      },
+    })
+
+    expect(result.errors).to.have.lengthOf(1)
+
+  })
+
+  it('allows an empty revision_history', function () {
+
+      const result = mandatoryTest_6_1_30(
+        {
+          ...minimalDoc,
+          document: {
+            ...minimalDoc.document,
+            tracking: {
+              ...minimalDoc.document.tracking,
+              revision_history: [],
+              version: '1',
+            },
+          },
+        }
+      )
+
+      expect(result.errors).to.have.lengthOf(0)
+    }
+  )
+})


### PR DESCRIPTION
when there are no revision history items, the test would always
respond with "mixed integer and semantic versioning" but that is
not correct as there is only one version and nothing to compare
it with