### PR TITLE
Fix/external pr workflows

### DIFF
--- a/.github/workflows/publish-report.yml
+++ b/.github/workflows/publish-report.yml
@@ -27,7 +27,7 @@ jobs:
         path: test-results.json
         reporter: mocha-json
     - name: c8 coverage report
-      uses: Nef10/lcov-reporter-action@v0.3.0
+      uses: Nef10/lcov-reporter-action@v0.4.0
       with:
         pr-number: ${{ env.PR_NUMBER }}
         github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish-report.yml
+++ b/.github/workflows/publish-report.yml
@@ -1,0 +1,31 @@
+name: 'Test Report'
+on:
+  workflow_run:
+    workflows: ['Run Tests']
+    types:
+      - completed
+jobs:
+  report:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Download workflow artifact
+      uses: dawidd6/action-download-artifact@v2.27.0
+      with:
+        workflow: tests.yml
+        run_id: ${{ github.event.workflow_run.id }}
+    - name: Set pr number env
+      run: |
+        PR_NUMBER=$(cat pr_number)
+        echo "PR_NUMBER=$PR_NUMBER" >> $GITHUB_ENV
+    - name: Test Report
+      uses: phoenix-actions/test-reporting@v12
+      id: test-report
+      with:
+        artifact: test-results
+        name: Mocha Tests
+        path: test-results.json
+        reporter: mocha-json
+    - name: c8 coverage report
+      uses: Nef10/lcov-reporter-action@v0.3.0
+      with:
+        pr-number: ${{ env.PR_NUMBER }}

--- a/.github/workflows/publish-report.yml
+++ b/.github/workflows/publish-report.yml
@@ -11,7 +11,8 @@ jobs:
     - name: Download workflow artifact
       uses: dawidd6/action-download-artifact@v2.27.0
       with:
-        workflow: tests.yml
+        workflow: run-tests.yml
+        name: test-results
         run_id: ${{ github.event.workflow_run.id }}
     - name: ls content for debugging
       run: ls -la

--- a/.github/workflows/publish-report.yml
+++ b/.github/workflows/publish-report.yml
@@ -14,8 +14,6 @@ jobs:
         workflow: run-tests.yml
         name: test-results
         run_id: ${{ github.event.workflow_run.id }}
-    - name: ls content for debugging
-      run: ls -la
     - name: Set pr number env
       run: |
         PR_NUMBER=$(cat pr_number)
@@ -32,3 +30,4 @@ jobs:
       uses: Nef10/lcov-reporter-action@v0.3.0
       with:
         pr-number: ${{ env.PR_NUMBER }}
+        github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish-report.yml
+++ b/.github/workflows/publish-report.yml
@@ -13,6 +13,8 @@ jobs:
       with:
         workflow: tests.yml
         run_id: ${{ github.event.workflow_run.id }}
+    - name: ls content for debugging
+      run: ls -la
     - name: Set pr number env
       run: |
         PR_NUMBER=$(cat pr_number)

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -16,16 +16,16 @@ jobs:
           node-version: 16
       - run: npm ci
       - run: npm run test-report
-      - name: Test Report
-        uses: phoenix-actions/test-reporting@v8
-        id: test-report
+      - name: Save PR number
+        env:
+          PR_NUMBER: ${{ github.event.number }}
+        run: |
+          echo $PR_NUMBER > ./pr_number
+      - uses: actions/upload-artifact@v3
         if: success() || failure()
         with:
-          name: Mocha Tests
-          path: test-results.json
-          reporter: mocha-json
-      - run: npm run test-coverage-lcov
-      - name: c8 coverage report
-        uses: romeovs/lcov-reporter-action@v0.2.16
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          name: test-results
+          path: |
+            test-results.json
+            coverage/lcov.info
+            pr_number

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -7,11 +7,6 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - name: Save PR number
-        env:
-          PR_NUMBER: ${{ github.event.number }}
-        run: |
-          echo $PR_NUMBER > ./pr_number
       - run: sudo apt-get install hunspell
       - uses: actions/checkout@v3
         with:
@@ -22,6 +17,11 @@ jobs:
       - run: npm ci
       - run: npm run test-report
       - run: npm run test-coverage-lcov
+      - name: Save PR number
+        env:
+          PR_NUMBER: ${{ github.event.number }}
+        run: |
+          echo $PR_NUMBER > ./pr_number
       - uses: actions/upload-artifact@v3
         if: success() || failure()
         with:

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -7,6 +7,11 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
+      - name: Save PR number
+        env:
+          PR_NUMBER: ${{ github.event.number }}
+        run: |
+          echo $PR_NUMBER > ./pr_number
       - run: sudo apt-get install hunspell
       - uses: actions/checkout@v3
         with:
@@ -16,16 +21,12 @@ jobs:
           node-version: 16
       - run: npm ci
       - run: npm run test-report
-      - name: Save PR number
-        env:
-          PR_NUMBER: ${{ github.event.number }}
-        run: |
-          echo $PR_NUMBER > ./pr_number
+      - run: npm run test-coverage-lcov
       - uses: actions/upload-artifact@v3
         if: success() || failure()
         with:
           name: test-results
           path: |
             test-results.json
-            coverage/lcov.info
+            coverage
             pr_number


### PR DESCRIPTION
Fixes https://github.com/secvisogram/csaf-validator-lib/issues/31

As stated on https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token the access for pull requests from public forked repositories is restricted to read for checks, etc. Available to private repositories only, you can configure these policy settings for a repository within the GitHub action settings.

Following the suggestion on https://github.com/phoenix-actions/test-reporting#recommended-setup-for-public-repositories for public repositories, we can use two seperate workflows running in two contexts (pull request and base branch)

Notable changes:
	- Seperated the action into two contexts -> running the test + publishing the results
	- Adapted the provided example on https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#using-data-from-the-triggering-workflow to save the PR number
	- Using the `lcov-reporter-action` fork https://github.com/Nef10/lcov-reporter-action which enables the use of the reporter within another context.

I already tested it on a PR within a fork as it won't be testable on this repository until merged into main: https://github.com/BIZFactoryGmbH/csaf-validator-lib/pull/6/