### PR TITLE
updated ajv-formats to version 3.0.0-rc.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,16 @@
 {
   "name": "csaf-validator-lib",
-  "version": "1.3.4",
+  "version": "1.3.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "csaf-validator-lib",
-      "version": "1.3.4",
+      "version": "1.3.5",
       "license": "MIT",
       "dependencies": {
         "ajv": "^8.11.2",
-        "ajv-formats": "^2.1.1",
+        "ajv-formats": "^3.0.0-rc.0",
         "bcp47": "^1.1.2",
         "cvss2js": "^1.1.0",
         "json-pointer": "^0.6.1",
@@ -149,9 +149,9 @@
       }
     },
     "node_modules/ajv-formats": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-2.1.1.tgz",
-      "integrity": "sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==",
+      "version": "3.0.0-rc.0",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.0-rc.0.tgz",
+      "integrity": "sha512-eyqaGv4OE7RMgW2GNujqwJZWFjOT4z0tQZTVnYiWtSDh9TFwD8CIsJ6ta065IblpZXcV3wFuy8y2gKFb1d0uPw==",
       "dependencies": {
         "ajv": "^8.0.0"
       },

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "ajv": "^8.11.2",
-    "ajv-formats": "^2.1.1",
+    "ajv-formats": "^3.0.0-rc.0",
     "bcp47": "^1.1.2",
     "cvss2js": "^1.1.0",
     "json-pointer": "^0.6.1",


### PR DESCRIPTION
Regarding issue https://github.com/secvisogram/csaf-validator-lib/issues/20

In order to fix this I upgraded ajv-formats to [pre-release version 3.0.0](https://github.com/ajv-validator/ajv-formats/releases/tag/v3.0.0-rc.0)
In this version the offset in the datetime string is required and omitting it causes an error.

In @domachine's [comment](https://github.com/secvisogram/csaf-validator-lib/issues/20#issuecomment-1130003351) he was worried about the correctness of his testing results, but all of them were [RFC3339](https://www.ietf.org/rfc/rfc3339.txt) compliant (see page 7 section 5.6).
