### PR TITLE
feat: add github action to publish new releases on npmjs.org

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,0 +1,33 @@
+# This workflow will run tests using node and then publish a package to GitHub Packages when a release is created
+# For more information see: https://docs.github.com/en/actions/publishing-packages/publishing-nodejs-packages
+
+name: NPM Package
+
+on:
+  release:
+    types: [created]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 16
+      - run: npm ci
+      - run: npm test
+
+  publish-npm:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 16
+          registry-url: https://registry.npmjs.org/
+      - run: npm ci
+      - run: npm publish --access public
+        env:
+          NPM_TOKEN: ${{secrets.npm_token}}

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -28,6 +28,6 @@ jobs:
           node-version: 16
           registry-url: https://registry.npmjs.org/
       - run: npm ci
-      - run: npm publish --access public
+      - run: npm publish
         env:
           NPM_TOKEN: ${{secrets.npm_token}}

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,3 @@
+//registry.npmjs.org/:_authToken=${NPM_TOKEN}
+@secvisogram:registry=https://registry.npmjs.org/
+always-auth=true

--- a/package.json
+++ b/package.json
@@ -10,6 +10,15 @@
     "test-coverage": "c8 node scripts/test.js",
     "test-coverage-lcov": "c8 --reporter lcovonly node scripts/test.js"
   },
+  "keywords": [
+    "csaf",
+    "csaf-validator-lib",
+    "csaf full validator",
+    "secvisogram"
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
   "dependencies": {
     "ajv": "^8.11.2",
     "ajv-formats": "^2.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,5 @@
 {
-  "name": "csaf-validator-lib",
-  "private": true,
+  "name": "@secvisogram/csaf-validator-lib",
   "type": "module",
   "license": "MIT",
   "scripts": {


### PR DESCRIPTION
In order to make this work a new githubaction-secret with the name `npm_token` must be created.
