### PR TITLE
Fix/issue 117

### DIFF
--- a/lib/mandatoryTests/mandatoryTest_6_1_14.js
+++ b/lib/mandatoryTests/mandatoryTest_6_1_14.js
@@ -1,4 +1,6 @@
 import semver from 'semver'
+import { compareZonedDateTimes } from '../shared/dateHelper.js'
+import * as docUtils from './shared/docUtils.js'
 
 const { gt, valid } = semver
 
@@ -16,7 +18,9 @@ export default function mandatoryTest_6_1_14(doc) {
         doc.document.tracking.revision_history
           .slice()
           .sort(
-            (a, z) => new Date(a.date).getTime() - new Date(z.date).getTime()
+            (a, z) =>
+              compareZonedDateTimes(a.date, z.date) ||
+              docUtils.compareVersions(z.number, a.number)
           )
           .map((e) => valid(e.number) ?? `${e.number}.0.0`)
       ).keys()

--- a/lib/mandatoryTests/mandatoryTest_6_1_16.js
+++ b/lib/mandatoryTests/mandatoryTest_6_1_16.js
@@ -1,3 +1,4 @@
+import { compareZonedDateTimes } from '../shared/dateHelper.js'
 import * as docUtils from './shared/docUtils.js'
 
 const {
@@ -35,8 +36,10 @@ export default function mandatoryTest_6_1_16(doc) {
           .slice()
           .sort(
             (a, z) =>
-              new Date(z.date).getTime() - new Date(a.date).getTime() ||
-              docUtils.compareVersions(a.number, z.number)
+              compareZonedDateTimes(
+                /** @type {string} */ (z.date),
+                /** @type {string} */ (a.date)
+              ) || docUtils.compareVersions(a.number, z.number)
           )[0].number
       ) !== normalizeVersion(doc.document.tracking.version)
     ) {

--- a/lib/mandatoryTests/mandatoryTest_6_1_21.js
+++ b/lib/mandatoryTests/mandatoryTest_6_1_21.js
@@ -1,3 +1,5 @@
+import { compareZonedDateTimes } from '../shared/dateHelper.js'
+
 /**
  * @param {unknown} doc
  */
@@ -12,8 +14,11 @@ export default function mandatoryTest_6_1_21(doc) {
       new Set(
         doc.document.tracking.revision_history
           .slice()
-          .sort(
-            (a, z) => new Date(a.date).getTime() - new Date(z.date).getTime()
+          .sort((a, z) =>
+            compareZonedDateTimes(
+              /** @type {string} */ (a.date),
+              /** @type {string} */ (z.date)
+            )
           )
           .map((e) =>
             // By using `parseInt` here we can deal with numeric and semantic versions

--- a/lib/optionalTests/optionalTest_6_2_5.js
+++ b/lib/optionalTests/optionalTest_6_2_5.js
@@ -1,4 +1,5 @@
 import Ajv from 'ajv/dist/jtd.js'
+import { compareZonedDateTimes } from '../shared/dateHelper.js'
 
 const ajv = new Ajv()
 
@@ -42,11 +43,18 @@ export default function optionalTest_6_2_5(doc) {
 
   const oldestRevisionHistoryItem = doc.document.tracking.revision_history
     .slice()
-    .sort((a, z) => new Date(a.date).getTime() - new Date(z.date).getTime())[0]
+    .sort((a, z) =>
+      compareZonedDateTimes(
+        /** @type {string} */ (a.date),
+        /** @type {string} */ (z.date)
+      )
+    )[0]
   if (
     oldestRevisionHistoryItem &&
-    new Date(doc.document.tracking.initial_release_date).getTime() <
-      new Date(oldestRevisionHistoryItem.date).getTime()
+    compareZonedDateTimes(
+      /** @type {string} */ (doc.document.tracking.initial_release_date),
+      /** @type {string} */ (oldestRevisionHistoryItem.date)
+    ) < 0
   ) {
     warnings.push({
       message: 'older initial release date than revision history',

--- a/lib/optionalTests/optionalTest_6_2_6.js
+++ b/lib/optionalTests/optionalTest_6_2_6.js
@@ -1,4 +1,5 @@
 import Ajv from 'ajv/dist/jtd.js'
+import { compareZonedDateTimes } from '../shared/dateHelper.js'
 
 const ajv = new Ajv()
 
@@ -42,11 +43,18 @@ export default function optionalTest_6_2_6(doc) {
 
   const newestRevisionHistoryItem = doc.document.tracking.revision_history
     .slice()
-    .sort((a, z) => new Date(z.date).getTime() - new Date(a.date).getTime())[0]
+    .sort((a, z) =>
+      compareZonedDateTimes(
+        /** @type {string} */ (z.date),
+        /** @type {string} */ (a.date)
+      )
+    )[0]
   if (
     newestRevisionHistoryItem &&
-    new Date(doc.document.tracking.current_release_date).getTime() <
-      new Date(newestRevisionHistoryItem.date).getTime()
+    compareZonedDateTimes(
+      /** @type {string} */ (doc.document.tracking.current_release_date),
+      /** @type {string} */ (newestRevisionHistoryItem.date)
+    ) < 0
   ) {
     warnings.push({
       message: 'older current release date than revision history',

--- a/lib/shared/dateHelper.js
+++ b/lib/shared/dateHelper.js
@@ -1,0 +1,21 @@
+import { Duration, ZonedDateTime } from '@js-joda/core'
+
+/**
+ * compare ZonedDateTimes from js-joda
+ * @param {ZonedDateTime | string} a
+ * @param {ZonedDateTime | string} b
+ * @returns {0|1|-1}
+ *
+ */
+export const compareZonedDateTimes = (a, b) => {
+  const date1 = a instanceof ZonedDateTime ? a : ZonedDateTime.parse(a)
+  const date2 = b instanceof ZonedDateTime ? b : ZonedDateTime.parse(b)
+  const duration = Duration.between(date1, date2)
+  if (duration.isZero()) {
+    return 0
+  } else if (duration.isNegative()) {
+    return 1
+  } else {
+    return -1
+  }
+}

--- a/lib/shared/dateHelper.js
+++ b/lib/shared/dateHelper.js
@@ -11,6 +11,10 @@ export const compareZonedDateTimes = (a, b) => {
   const date1 = a instanceof ZonedDateTime ? a : ZonedDateTime.parse(a)
   const date2 = b instanceof ZonedDateTime ? b : ZonedDateTime.parse(b)
   const duration = Duration.between(date1, date2)
+
+  // return number based on js sort function
+  // > negative if a is less than b, positive if a is greater than b, and zero if they are equal.
+  // [Sort Documentation](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/sort#comparefn)
   if (duration.isZero()) {
     return 0
   } else if (duration.isNegative()) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,8 @@
       "version": "1.3.12",
       "license": "MIT",
       "dependencies": {
+        "@js-joda/core": "^5.5.3",
+        "@js-joda/timezone": "^2.18.0",
         "ajv": "^8.11.2",
         "ajv-formats": "^2.1.1",
         "bcp47": "^1.1.2",
@@ -74,6 +76,19 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@js-joda/core": {
+      "version": "5.5.3",
+      "resolved": "https://registry.npmjs.org/@js-joda/core/-/core-5.5.3.tgz",
+      "integrity": "sha512-7dqNYwG8gCt4hfg5PKgM7xLEcgSBcx/UgC92OMnhMmvAnq11QzDFPrxUkNR/u5kn17WWLZ8beZ4A3Qrz4pZcmQ=="
+    },
+    "node_modules/@js-joda/timezone": {
+      "version": "2.18.0",
+      "resolved": "https://registry.npmjs.org/@js-joda/timezone/-/timezone-2.18.0.tgz",
+      "integrity": "sha512-NjNDwj2AuFzVgW1XvKq3t0oH/BwK+Zsu6TiCsDkQZFx4h3W3oKgmUJUKleMBHMFJvh7sQRTK9hSqK/6izBuyAA==",
+      "peerDependencies": {
+        "@js-joda/core": ">=1.11.0"
       }
     },
     "node_modules/@types/chai": {

--- a/package.json
+++ b/package.json
@@ -20,6 +20,8 @@
     "access": "public"
   },
   "dependencies": {
+    "@js-joda/core": "^5.5.3",
+    "@js-joda/timezone": "^2.18.0",
     "ajv": "^8.11.2",
     "ajv-formats": "^2.1.1",
     "bcp47": "^1.1.2",


### PR DESCRIPTION
Fixes #117 

native js Date library does not fully support RFC standard. (see: [Date](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date#date_time_string_format))

To solve this dates are now compared through the js-joda library
