### PR TITLE
Fix/dateparsing exception

### DIFF
--- a/lib/shared/dateHelper.js
+++ b/lib/shared/dateHelper.js
@@ -2,6 +2,9 @@ import { Duration, ZonedDateTime } from '@js-joda/core'
 
 /**
  * compare ZonedDateTimes from js-joda
+ * returns a negative number if a is less than b, positive if a is greater than b, and zero if they are equal.
+ * This function also returns 0 if one of the given values could not be parsed.
+ *
  * @param {ZonedDateTime | string} a
  * @param {ZonedDateTime | string} b
  * @returns {0|1|-1}

--- a/lib/shared/dateHelper.js
+++ b/lib/shared/dateHelper.js
@@ -8,18 +8,23 @@ import { Duration, ZonedDateTime } from '@js-joda/core'
  *
  */
 export const compareZonedDateTimes = (a, b) => {
-  const date1 = a instanceof ZonedDateTime ? a : ZonedDateTime.parse(a)
-  const date2 = b instanceof ZonedDateTime ? b : ZonedDateTime.parse(b)
-  const duration = Duration.between(date1, date2)
+  // catch js-joda exception if a or b can't be parsed
+  try {
+    const date1 = a instanceof ZonedDateTime ? a : ZonedDateTime.parse(a)
+    const date2 = b instanceof ZonedDateTime ? b : ZonedDateTime.parse(b)
+    const duration = Duration.between(date1, date2)
 
-  // return number based on js sort function
-  // > negative if a is less than b, positive if a is greater than b, and zero if they are equal.
-  // [Sort Documentation](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/sort#comparefn)
-  if (duration.isZero()) {
+    // return number based on js sort function
+    // > negative if a is less than b, positive if a is greater than b, and zero if they are equal.
+    // [Sort Documentation](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/sort#comparefn)
+    if (duration.isZero()) {
+      return 0
+    } else if (duration.isNegative()) {
+      return 1
+    } else {
+      return -1
+    }
+  } catch(e) {
     return 0
-  } else if (duration.isNegative()) {
-    return 1
-  } else {
-    return -1
   }
 }

--- a/tests/dateHelper.js
+++ b/tests/dateHelper.js
@@ -1,0 +1,32 @@
+import { expect } from 'chai'
+import { compareZonedDateTimes } from '../lib/shared/dateHelper.js'
+
+describe('dateHelper', function () {
+  const date1 = '2023-11-06T13:00:00.000Z'
+  const date2 = '2023-12-04T11:00:00.000Z'
+  const invalidDate = '2023-12-04T11:00:00.000'
+
+  it('equal dates', function () {
+    expect(compareZonedDateTimes(date1, date1)).to.be.eq(0)
+  })
+
+  it('second date newer', function () {
+    expect(compareZonedDateTimes(date1, date2)).to.be.eq(-1)
+  })
+
+  it('first date newer', function () {
+    expect(compareZonedDateTimes(date2, date1)).to.be.eq(1)
+  })
+
+  it('first date invalid', function () {
+    expect(compareZonedDateTimes(invalidDate, date1)).to.be.eq(0)
+  })
+
+  it('second date invalid', function () {
+    expect(compareZonedDateTimes(date1, invalidDate)).to.be.eq(0)
+  })
+
+  it('both dates invalid', function () {
+    expect(compareZonedDateTimes(invalidDate, invalidDate)).to.be.eq(0)
+  })
+})


### PR DESCRIPTION
Fixes https://github.com/secvisogram/secvisogram/issues/524

# Cause
The dateHelper module, which parses the date strings of the document, threw an error when the string was invalid.

# Changes
- Catch error from above and `return 0` (pretend dates are equal) so that no errors occur except the main issue, which is that the string is not a valid RFC datetime.
- Add tests for dateHelper module