### PR TITLE
fix: keys sorted alphabetically 6_2_13

### DIFF
--- a/lib/optionalTests/optionalTest_6_2_13.js
+++ b/lib/optionalTests/optionalTest_6_2_13.js
@@ -16,6 +16,7 @@ export default function optionalTest_6_2_13(doc) {
   const checkObjectKeysSorting = (collator, prefix, obj) => {
     if (typeof obj !== 'object' || obj == null) return
     if (Array.isArray(obj)) {
+      // check sorting for elements inside the array but not the array itself
       obj.forEach((e, i) => {
         checkObjectKeysSorting(collator, prefix + '/' + i, e)
       })

--- a/lib/optionalTests/optionalTest_6_2_13.js
+++ b/lib/optionalTests/optionalTest_6_2_13.js
@@ -19,6 +19,7 @@ export default function optionalTest_6_2_13(doc) {
       obj.forEach((e, i) => {
         checkObjectKeysSorting(collator, prefix + '/' + i, e)
       })
+      return
     }
 
     const keys = /** @type {Array<keyof obj>} */ (Object.keys(obj))


### PR DESCRIPTION
Fixes #150 

# Changes
Adding a return statement for arrays

The function executes recursive calls for all items in an array.
An array itself cannot be tested though, because it has no keys that could be alphabetically sorted.
This fix makes sure that the function returns after the items of the array have all been checked.

```javascript
const checkObjectKeysSorting = (collator, prefix, obj) => {
  if (typeof obj !== 'object' || obj == null) return
  if (Array.isArray(obj)) {
    obj.forEach((e, i) => {
      checkObjectKeysSorting(collator, prefix + '/' + i, e)
    })
    return // <-- this was added
  }

  ...
}
```