### PR TITLE
fix: 400 status response code for csaf.io domain due to missing useragent

### DIFF
--- a/lib/informativeTests/shared/testURL.js
+++ b/lib/informativeTests/shared/testURL.js
@@ -20,7 +20,7 @@ export default async function testURL(url, onError) {
     const res = await request(url, {
       method: 'HEAD',
       headers: {
-        'user-agent': userAgent
+        'User-Agent': userAgent
       }
     })
     if (res.statusCode < 200 || 400 <= res.statusCode) {

--- a/lib/informativeTests/shared/testURL.js
+++ b/lib/informativeTests/shared/testURL.js
@@ -1,13 +1,27 @@
+import { createRequire } from 'module'
 import { request } from 'undici'
+
+/**
+ * @type {{
+ *  name: string
+ *  version: string
+ * }}
+ */
+const packageInfo = createRequire(import.meta.url)('../../../package.json')
 
 /**
  * @param {string} url
  * @param {() => void} onError
  */
 export default async function testURL(url, onError) {
+  // set user-agent to csaf-validator-lib/VERSION
+  const userAgent = `${packageInfo.name.split('/').at(-1)}/${packageInfo.version}`
   try {
     const res = await request(url, {
       method: 'HEAD',
+      headers: {
+        'user-agent': userAgent
+      }
     })
     if (res.statusCode < 200 || 400 <= res.statusCode) {
       onError()


### PR DESCRIPTION
# Changes
- add user agent "csaf-validator-lib/VERSION" to undici requests in testURL module

Fixes #169 