### PR TITLE
fix(performance): #201 add missing await to checkBranches

### DIFF
--- a/lib/informativeTests/informativeTest_6_3_8.js
+++ b/lib/informativeTests/informativeTest_6_3_8.js
@@ -304,7 +304,7 @@ export default async function informativeTest_6_3_8(
         `${prefix}${branchIndex}/product/name`,
         branch.product?.name
       )
-      checkBranches(
+      await checkBranches(
         `${prefix}${branchIndex}/branches/`,
         Array.isArray(branch.branches) ? branch.branches : []
       )


### PR DESCRIPTION
fix bug:  missing await in checkBranches

improve performance by the following steps:

-  segment text before callings hunspell and cache results
- keep hunspell process open and communicate with the process with a pipe 