### PR TITLE
chore(renovate): add github action to execute renovate

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["group:allNonMajor", ":automergeDisabled"],
+  "baseBranches": ["main", "development"],
+  "rebaseWhen": "conflicted",
+  "labels": ["dependencies"],
+  "platformAutomerge": false,
+  "automergeStrategy": "merge-commit",
+  "prHourlyLimit": 2,
+  "prConcurrentLimit": 1,
+  "packageRules": [
+    {
+      "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
+      "groupName": "all (non-major) dependencies",
+      "groupSlug": "all-non-major",
+      "matchCurrentValue": "!/^v?0\\./",
+      "matchPackageNames": ["*"]
+    }
+  ]
+}

--- a/.github/workflows/rennovate.yml
+++ b/.github/workflows/rennovate.yml
@@ -1,0 +1,24 @@
+name: "Renovate Weekly Update"
+
+on:
+  schedule:
+    - cron: '0 4 * * 2'
+  workflow_dispatch:  # optional: allows manual triggering
+
+jobs:
+  renovate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4.2.2
+      # Don't waste time starting Renovate if JSON is invalid
+      - name: Validate Renovate JSON
+        run: jq type .github/renovate.json
+      - name: Run Renovate
+        uses: renovatebot/github-action@v41.0.13
+        with:
+          token: ${{ secrets.RENOVATE_TOKEN }}
+        env:
+          # Repository taken from variable to keep configuration file generic
+          RENOVATE_REPOSITORIES: ${{ github.repository }}
+          LOG_LEVEL: DEBUG


### PR DESCRIPTION
Add github action to execute renovate.

The renovate action needs a Token with name RENOVATE_TOKEN.

Therefore, a Fine-grained personal access token has to be created in Settings/Developer Settings with the following permissions:

Permission               | Access              | Level
--------------------- | ----------------- | --
Members                 | Read-only         | Organization
Commit statuses     | Read and write | Repository or Organization
Contents                 | Read and write | Repository or Organization
Dependabot alerts  | Read-only         | Repository or Organization
Issues                       | Read and write | Repository or Organization
Pull requests           | Read and write | Repository or Organization
Workflows               | Read and write | Repository or Organization



This token has to be added to the secrets of the repository

![grafik](https://github.com/user-attachments/assets/5aca6fa9-33e2-4af0-b252-e9b4fe7e4b13)
