### PR TITLE
chore: remove always-auth field from npmrc

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,3 +1,2 @@
 //registry.npmjs.org/:_authToken=${NPM_TOKEN}
 @secvisogram:registry=https://registry.npmjs.org/
-always-auth=true


### PR DESCRIPTION
This field is deprecated and was removed from npm.

Closes #231.