### PR TITLE
Node.js 22 support

### DIFF
--- a/.github/workflows/publish-report.yml
+++ b/.github/workflows/publish-report.yml
@@ -12,11 +12,24 @@ permissions:
 jobs:
   report:
     runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+
+        #
+        # The test report is published for every supported nodejs version. But the
+        # coverage information is reported for the latest nodejs version only. When
+        # changing this array here make sure to update the latest version below
+        # (next comment).
+        #
+
+        node-version: [20.x, 22.x]
+
     steps:
     - name: Download workflow artifact
       uses: actions/download-artifact@v4
       with:
-        name: test-results
+        name: test-results-${{ matrix.node-version }}
         run-id: ${{ github.event.workflow_run.id }}
         github-token: ${{ secrets.GITHUB_TOKEN }}
     - name: Set pr number env
@@ -27,11 +40,18 @@ jobs:
       uses: phoenix-actions/test-reporting@v15
       id: test-report
       with:
-        artifact: test-results
-        name: Mocha Tests
+        artifact: test-results-${{ matrix.node-version }}
+        name: Mocha Tests (node v${{ matrix.node-version }})
         path: test-results.json
         reporter: mocha-json
     - name: c8 coverage report
+
+      #
+      # The coverage report is generated for the latest node version only.
+      # Make sure, to update this when changing the matrix above.
+      #
+
+      if: ${{ matrix.node-version == '22.x' }}
       uses: Nef10/lcov-reporter-action@v0.4.0
       with:
         pr-number: ${{ env.PR_NUMBER }}

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -9,6 +9,11 @@ permissions:
 jobs:
   test:
     runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [20.x, 22.x]
+
     steps:
       - run: sudo apt-get install hunspell
       - uses: actions/checkout@v4
@@ -16,7 +21,7 @@ jobs:
           submodules: recursive
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: ${{ matrix.node-version }}
       - run: npm ci
       - run: npm run test-report
       - run: npm run test-coverage-lcov
@@ -28,7 +33,7 @@ jobs:
       - uses: actions/upload-artifact@v4
         if: success() || failure()
         with:
-          name: test-results
+          name: test-results-${{ matrix.node-version }}
           path: |
             test-results.json
             coverage

--- a/README.md
+++ b/README.md
@@ -547,7 +547,7 @@ export const weaknesses: Array<{ id: string; name: string }>
 
 ## Testing
 
-Tests are implemented using [mocha](https://mochajs.org/). The minimal supported Node.js version is **14**. They can be run using the following command:
+Tests are implemented using [mocha](https://mochajs.org/). The minimal supported Node.js version is **20**. They can be run using the following command:
 
 ```sh
 npm test


### PR DESCRIPTION
This PR will update the Node.js version typings to 22.x. It also introduces a matrix github workflow that tests against the nodejs version 20.x and 22.x. Since I updated the `publish-report.yml` workflow which runs against the base branch only (for permission reasons, PRs run with a read-only github token only) the checks fail here until it is merged into the `main` branch. For testing purposes I forked this repository, merged the branch there into `main` and created a test PR: https://github.com/domachine/csaf-validator-lib/pull/1.