### PR TITLE
set NODE_EXTRA_CA_CERTS to fix test 6.3.6 and 6.3.7 

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -24,7 +24,11 @@ jobs:
           node-version: ${{ matrix.node-version }}
       - run: npm ci
       - run: npm run test-report
+        env:
+          NODE_EXTRA_CA_CERTS: /etc/ssl/certs/ca-certificates.crt
       - run: npm run test-coverage-lcov
+        env:
+          NODE_EXTRA_CA_CERTS: /etc/ssl/certs/ca-certificates.crt
       - name: Save PR number
         env:
           PR_NUMBER: ${{ github.event.number }}


### PR DESCRIPTION
add NODE_EXTRA_CA_CERTS=/etc/ssl/certs/ca-certificates.crt to fix test 6.3.6 and 6.3.7

https://github.com/secvisogram/csaf-validator-lib/issues/497