### PR TITLE
fix(CSAF2.1): #448 remove test 6.1.8 from excluded test

### DIFF
--- a/tests/csaf_2_1/oasis.js
+++ b/tests/csaf_2_1/oasis.js
@@ -10,7 +10,6 @@ import * as mandatory from '../../csaf_2_1/mandatoryTests.js'
  * Once all tests are implemented for CSAF 2.1 this should be deleted.
  */
 const excluded = [
-  '6.1.8',
   '6.1.26',
   '6.1.27.3',
   '6.1.27.4',


### PR DESCRIPTION
Remove test from excluded because https://github.com/oasis-tcs/csaf/issues/1173 is fixed and the cvss_v4 schema has been updated in https://github.com/secvisogram/csaf-validator-lib/pull/348